### PR TITLE
Adjust some things to SS2021 VM lecture at the TUM

### DIFF
--- a/cma/test_vm.py
+++ b/cma/test_vm.py
@@ -152,7 +152,8 @@ def test_storea_and_loada():
         'loada %d' % c_ref,
         'mul',
         'add',
-        'storea %d' % a_ref
+        'storea %d' % a_ref,
+        'pop'
     ]
     # TODO: add additional state checks
 

--- a/cma/test_vm.py
+++ b/cma/test_vm.py
@@ -11,7 +11,7 @@ def _test_binary_op(op_name, x, y, z):
     vm = VM(instructions)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 1
+    assert vm._get_sp() == 0
     assert vm.peek() == z
 
 
@@ -24,7 +24,7 @@ def _test_unary_op(op_name, x, z):
     vm = VM(instructions)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 1
+    assert vm._get_sp() == 0
     assert vm.peek() == z
 
 
@@ -160,12 +160,12 @@ def test_storea_and_loada():
     b_val, c_val = 7, 13
 
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     vm._write(b_val, b_ref)
     vm._write(c_val, c_ref)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     a_val = vm._read(a_ref)
     assert a_val == b_val + b_val * c_val
 
@@ -178,10 +178,10 @@ def test_loadc():
     # TODO: add additional state checks
 
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 1
+    assert vm._get_sp() == 0
     assert vm.peek() == c
 
 
@@ -193,10 +193,10 @@ def test_pop():
     # TODO: add additional state checks
 
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
 
 
 def test_jump_and_jumpz():
@@ -227,7 +227,7 @@ def test_jump_and_jumpz():
 
     x_val, y_val = 4, 3
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     vm._write(x_val, x_ref)
     vm._write(y_val, y_ref)
     while not vm.halted:
@@ -238,7 +238,7 @@ def test_jump_and_jumpz():
 
     x_val, y_val = 3, 4
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     vm._write(x_val, x_ref)
     vm._write(y_val, y_ref)
     while not vm.halted:
@@ -260,12 +260,12 @@ def test_dup():
         'dup'
     ]
     vm = VM(instructions)
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == -1
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 2
+    assert vm._get_sp() == 1
+    assert vm._read(0) == 42
     assert vm._read(1) == 42
-    assert vm._read(2) == 42
     pass
 
 
@@ -321,6 +321,6 @@ def test_new():
     assert a_ref > vm.EP
     assert b_ref > vm.EP
     assert c_ref > vm.EP
-    assert vm.maxS - a_ref == 5
+    assert (vm.maxS+1) - a_ref == 5
     assert a_ref - b_ref == 10
     assert b_ref - c_ref == 1

--- a/cma/test_vm.py
+++ b/cma/test_vm.py
@@ -11,7 +11,7 @@ def _test_binary_op(op_name, x, y, z):
     vm = VM(instructions)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == 1
     assert vm.peek() == z
 
 
@@ -24,7 +24,7 @@ def _test_unary_op(op_name, x, z):
     vm = VM(instructions)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == 1
     assert vm.peek() == z
 
 
@@ -160,12 +160,12 @@ def test_storea_and_loada():
     b_val, c_val = 7, 13
 
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     vm._write(b_val, b_ref)
     vm._write(c_val, c_ref)
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     a_val = vm._read(a_ref)
     assert a_val == b_val + b_val * c_val
 
@@ -178,10 +178,10 @@ def test_loadc():
     # TODO: add additional state checks
 
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 0
+    assert vm._get_sp() == 1
     assert vm.peek() == c
 
 
@@ -193,10 +193,10 @@ def test_pop():
     # TODO: add additional state checks
 
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
 
 
 def test_jump_and_jumpz():
@@ -227,7 +227,7 @@ def test_jump_and_jumpz():
 
     x_val, y_val = 4, 3
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     vm._write(x_val, x_ref)
     vm._write(y_val, y_ref)
     while not vm.halted:
@@ -238,7 +238,7 @@ def test_jump_and_jumpz():
 
     x_val, y_val = 3, 4
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     vm._write(x_val, x_ref)
     vm._write(y_val, y_ref)
     while not vm.halted:
@@ -260,12 +260,12 @@ def test_dup():
         'dup'
     ]
     vm = VM(instructions)
-    assert vm._get_sp() == -1
+    assert vm._get_sp() == 0
     for _ in range(len(instructions)):
         vm.step()
-    assert vm._get_sp() == 1
-    assert vm._read(0) == 42
+    assert vm._get_sp() == 2
     assert vm._read(1) == 42
+    assert vm._read(2) == 42
     pass
 
 

--- a/cma/visualization/__init__.py
+++ b/cma/visualization/__init__.py
@@ -11,7 +11,9 @@ def render_vm_state_to_html(vm):
         "FP": vm.FP,
     })
 
-    memory_html = generate_memory_with_pointers_html(pointed_memory)
+    # start at -1: always include the black block representing the end of stack
+    memory_html = generate_memory_with_pointers_html(pointed_memory, -1)
+    memory_tikz = generate_memory_with_pointers_tikz(pointed_memory, -1)
 
     return generate_row_html(
         generate_column_html(
@@ -40,9 +42,7 @@ def render_vm_state_to_html(vm):
                     50,
                     generate_copyable_tab_pane_html(
                         "LaTeX/Tikz",
-                        generate_tikz_document(
-                            generate_memory_with_pointers_tikz(pointed_memory),
-                        )
+                        generate_tikz_document(memory_tikz)
                     ),
                 ),
             ),

--- a/cma/visualization/__init__.py
+++ b/cma/visualization/__init__.py
@@ -9,11 +9,11 @@ def render_vm_state_to_html(vm):
         "EP": vm.EP,
         "HP": vm.HP,
         "FP": vm.FP,
-    })
+    }, 1) #address 0 is unused
 
-    # start at -1: always include the black block representing the end of stack
-    memory_html = generate_memory_with_pointers_html(pointed_memory, -1)
-    memory_tikz = generate_memory_with_pointers_tikz(pointed_memory, -1)
+    # start at 0: always include the black block representing the end of stack
+    memory_html = generate_memory_with_pointers_html(pointed_memory, 0)
+    memory_tikz = generate_memory_with_pointers_tikz(pointed_memory, 0)
 
     return generate_row_html(
         generate_column_html(

--- a/cma/visualization/html.py
+++ b/cma/visualization/html.py
@@ -1,4 +1,4 @@
-from .memory import generate_memory_with_pointers, get_cell_pointers
+from .memory import generate_memory_with_pointers, get_cell_pointers, is_cell_oob
 
 def generate_tab_pane_html(title, body):
     return f"""
@@ -60,21 +60,23 @@ def generate_program_tab_pane_html(program, program_counter, labels):
 
 def generate_cell_html(cell, _rendered_index, memory_index):
     value, pointers = get_cell_pointers(cell)
+    pointer_list = ", ".join(pointers)
 
-    if memory_index == 0 and value == None:
+    memory_index_string = memory_index if len(pointers)>0 or not is_cell_oob(value) else ""
+    if is_cell_oob(value):
         return f"""
             <tr class="cell">
-                <td></td>
+                <td>{memory_index_string}</td>
                 <td class="value" style="border: 1px solid #333; background-color: black;">&nbsp;</td>
+                <td>{pointer_list}</td>
             </tr>
         """
 
-    value_or_empty_string = value if value != None else ""
-    pointer_list = ", ".join(pointers)
+    value_or_empty_string = str(value) if value != None else ""
 
     return f"""
         <tr class="cell">
-            <td>{memory_index}</td>
+            <td>{memory_index_string}</td>
             <td class="value" style="border: 1px solid #333; text-align: center;">{value_or_empty_string}</td>
             <td>{pointer_list}</td>
         </tr>
@@ -88,8 +90,8 @@ def generate_dots_html(_rendered_index):
         </tr>
     """
 
-def generate_memory_with_pointers_html(pointed_memory):
-    cells = generate_memory_with_pointers(pointed_memory, generate_cell_html, generate_dots_html)
+def generate_memory_with_pointers_html(pointed_memory, min_addr = None, max_addr = None):
+    cells = generate_memory_with_pointers(pointed_memory, generate_cell_html, generate_dots_html, min_addr, max_addr)
     reversed_cells = reversed(cells)
     rendered_cells = "\n".join(reversed_cells)
     return f"""

--- a/cma/visualization/memory.py
+++ b/cma/visualization/memory.py
@@ -3,14 +3,21 @@ class PointedCell:
         self.value = value
         self.pointer = pointer
 
+class OOBCell:
+    pass
+
 def point_to_cells(memory, pointers):
-    pointed_memory = memory[::]
+    pointed_memory = {location: memory[location] for location in range(len(memory))}
 
     for pointer, location in pointers.items():
-        if 0 <= location < len(pointed_memory):
-            pointed_memory[location] = PointedCell(pointed_memory[location], pointer)
+        # get instead of [] to have PointedCells with value==OOBCell instead of KeyErrors for out-of-bounds pointers
+        # Note that get will still return None if the location is undefined in memory.
+        pointed_memory[location] = PointedCell(pointed_memory.get(location, OOBCell()), pointer)
 
     return pointed_memory
+
+def is_cell_oob(cell):
+    return isinstance(cell, OOBCell)
 
 def get_cell_pointers(cell):
     pointers = []
@@ -21,19 +28,26 @@ def get_cell_pointers(cell):
 
     return cell, pointers
 
-def generate_memory_with_pointers(pointed_memory, render_cell, render_dots):
+def generate_memory_with_pointers(pointed_memory, render_cell, render_dots, min_addr = None, max_addr = None):
+    if min_addr == None:
+        min_addr = min(pointed_memory.keys())
+    if max_addr == None:
+        max_addr = max(pointed_memory.keys()) + 1
+
     skipped_cells = []
     rendered_dots = False
     rendered_index = 0
 
-    for memory_index, cell in enumerate(pointed_memory):
-        if cell == None and not rendered_dots and memory_index > 0:
+    for memory_index in range(min_addr, max_addr):
+        # Note that get will still return None if the location is undefined in memory.
+        cell = pointed_memory.get(memory_index, OOBCell())
+        if cell == None and not rendered_dots and rendered_index != 0:
             rendered_dots = True
             skipped_cells.append(
                 render_dots(rendered_index)
             )
             rendered_index += 1
-        elif cell != None or memory_index == 0:
+        elif cell != None or rendered_index == 0:
             rendered_dots = False
             skipped_cells.append(
                 render_cell(cell, rendered_index, memory_index)

--- a/cma/visualization/memory.py
+++ b/cma/visualization/memory.py
@@ -6,8 +6,10 @@ class PointedCell:
 class OOBCell:
     pass
 
-def point_to_cells(memory, pointers):
-    pointed_memory = {location: memory[location] for location in range(len(memory))}
+def point_to_cells(memory, pointers, min_addr = 0, max_addr = None):
+    if max_addr == None:
+        max_addr = len(memory)
+    pointed_memory = {location: memory[location] for location in range(min_addr, max_addr)}
 
     for pointer, location in pointers.items():
         # get instead of [] to have PointedCells with value==OOBCell instead of KeyErrors for out-of-bounds pointers

--- a/cma/visualization/tikz.py
+++ b/cma/visualization/tikz.py
@@ -1,36 +1,39 @@
-from .memory import generate_memory_with_pointers, get_cell_pointers
+from .memory import generate_memory_with_pointers, get_cell_pointers, is_cell_oob
 
 def generate_cell_tikz(cell, rendered_index, memory_index):
     value, pointers = get_cell_pointers(cell)
-    value_or_empty_string = str(value) if value != None else ""
 
-    if rendered_index == 0:
-        return r"\node[draw, fill=black, minimum width=1cm, minimum height=0.5cm] (node_%d) {};" % (rendered_index)
-
+    fill_param = ", fill=black" if is_cell_oob(value) else ""
+    above_param = r", above=0cm of node_%d" % (rendered_index - 1) if rendered_index != 0 else ""
+    value_string = str(value) if value != None and not is_cell_oob(value) else ""
+    address_string = r"""
+        \node[left=0cm of node_%d, anchor=east, color=black!40] {\small %d};""" % (rendered_index, memory_index) if len(pointers)>0 or not is_cell_oob(value) else ""
     pointer_list = ", ".join(pointers)
 
     return r"""
-        \node[draw, minimum width=1cm, minimum height=0.5cm, above=0cm of node_%d] (node_%d) {%s};
-        \node[left=0cm of node_%d, anchor=east, color=black!40] {\small %d};
-        \node[right=0.5cm of node_%d, anchor=west] {%s};
-    """ % (
-            rendered_index - 1,
+        \node[draw, minimum width=1cm, minimum height=0.5cm%s%s] (node_%d) {%s};%s
+        \node[right=0.5cm of node_%d, anchor=west] {%s};""" % (
+            fill_param,
+            above_param,
             rendered_index,
-            value_or_empty_string,
+            value_string,
+            
+            address_string,
+            
             rendered_index,
-            memory_index,
-            rendered_index,
-            pointer_list,
+            pointer_list
         )
 
 def generate_dots_tikz(rendered_index):
     if rendered_index == 0:
-        return r"\node[draw, minimum width=1cm] (node_%d) {...};" % (rendered_index)
+        return r"""
+        \node[draw, minimum width=1cm] (node_%d) {...};""" % (rendered_index)
 
-    return r"\node[draw, minimum width=1cm, above=0cm of node_%d] (node_%d) {...};" % (rendered_index - 1, rendered_index)
+    return r"""
+        \node[draw, minimum width=1cm, above=0cm of node_%d] (node_%d) {...};""" % (rendered_index - 1, rendered_index)
 
-def generate_memory_with_pointers_tikz(pointed_memory):
-    cells = generate_memory_with_pointers(pointed_memory, generate_cell_tikz, generate_dots_tikz)
+def generate_memory_with_pointers_tikz(pointed_memory, min_addr = None, max_addr = None):
+    cells = generate_memory_with_pointers(pointed_memory, generate_cell_tikz, generate_dots_tikz, min_addr, max_addr)
     return "\n".join(cells)
 
 def generate_tikz_document(drawing):
@@ -39,8 +42,7 @@ def generate_tikz_document(drawing):
 \usetikzlibrary{positioning}
 
 \begin{document}
-    \begin{tikzpicture}
-        %s
+    \begin{tikzpicture}%s
     \end{tikzpicture}
 \end{document}
-    """ % drawing
+""" % drawing

--- a/cma/vm.py
+++ b/cma/vm.py
@@ -1,4 +1,4 @@
-from visualization import render_vm_state_to_html
+from .visualization import render_vm_state_to_html
 import logging
 import itertools
 import re

--- a/cma/vm.py
+++ b/cma/vm.py
@@ -202,7 +202,7 @@ class VM:
         for i in range(m):
             w = self._read_sp_rel(i-m)
             self._write(w, a + i)
-        self._set_sp_rel(m-1)
+        self._dec_sp()
 
     @op()
     def op_dup(self):
@@ -235,7 +235,6 @@ class VM:
     def op_storea(self, a):
         w = self._read_sp_rel(0)
         self._write(w, a)
-        self._dec_sp()
 
     @op(address)
     def op_loadc(self, q):

--- a/cma/vm.py
+++ b/cma/vm.py
@@ -1,4 +1,4 @@
-from .visualization import render_vm_state_to_html
+from visualization import render_vm_state_to_html
 import logging
 import itertools
 import re
@@ -114,12 +114,12 @@ class VM:
         self.C = [parse_instruction(i, idx, self.labels) for idx, i in enumerate(C)] # program store
         self.maxC = len(C) - 1 # max memory address in program store
         self.PC = 0 # program counter
-        self.FP = 0
+        self.FP = -1
         self.S = [None for __ in range(memory_size)] # main memory
         self.maxS = memory_size-1 # max memory address in main memory
-        self.SP = 0 # stack pointer
+        self.SP = -1 # stack pointer
         self.EP = memory_size // 4
-        self.HP = self.maxS
+        self.HP = self.maxS + 1
         self.halted = False
 
     def _set_sp_rel(self, rel_idx):

--- a/cma/vm.py
+++ b/cma/vm.py
@@ -114,10 +114,10 @@ class VM:
         self.C = [parse_instruction(i, idx, self.labels) for idx, i in enumerate(C)] # program store
         self.maxC = len(C) - 1 # max memory address in program store
         self.PC = 0 # program counter
-        self.FP = -1
+        self.FP = 0
         self.S = [None for __ in range(memory_size)] # main memory
         self.maxS = memory_size-1 # max memory address in main memory
-        self.SP = -1 # stack pointer
+        self.SP = 0 # stack pointer
         self.EP = memory_size // 4
         self.HP = self.maxS + 1
         self.halted = False


### PR DESCRIPTION
In the SS2021 VM lecture at the TUM, `store` and `storea` are defined to leave the stored value(s) on the stack instead of removing them. This fix implements this.